### PR TITLE
Add HTML tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,15 @@
 # agency
+
+## Running tests
+
+Install BeautifulSoup:
+
+```bash
+pip install beautifulsoup4
+```
+
+Then run the tests with:
+
+```bash
+python -m unittest
+```

--- a/tests/test_tagline.py
+++ b/tests/test_tagline.py
@@ -1,0 +1,23 @@
+import os
+import unittest
+from bs4 import BeautifulSoup
+
+class TestTagline(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        html_path = os.path.join(os.path.dirname(os.path.dirname(__file__)), 'index.html')
+        with open(html_path, encoding='utf-8') as f:
+            cls.soup = BeautifulSoup(f, 'html.parser')
+
+    def test_tagline_phrase_present(self):
+        text = self.soup.get_text()
+        self.assertIn('TÍN NHIỆM', text)
+
+    def test_partner_slides_count(self):
+        carousel = self.soup.find(id='partnersCarousel')
+        self.assertIsNotNone(carousel, 'partnersCarousel element not found')
+        slides = carousel.find_all('div', class_='w-full flex-shrink-0 px-4', recursive=False)
+        self.assertEqual(len(slides), 2)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `test_tagline.py` verifying tagline and partner slides
- document how to run the tests in `README.md`

## Testing
- `python -m unittest discover -s tests -v 2>&1 | sed -n '1,14p' | cut -c1-200`

------
https://chatgpt.com/codex/tasks/task_b_685ac1fdb4588324bff47442759d0923